### PR TITLE
Add checks to ensure reasonable maximum clique size

### DIFF
--- a/teaser/include/teaser/registration.h
+++ b/teaser/include/teaser/registration.h
@@ -28,6 +28,7 @@ namespace teaser {
  * Struct to hold solution to a registration problem
  */
 struct RegistrationSolution {
+  bool valid = true;
   double scale;
   Eigen::Vector3d translation;
   Eigen::Matrix3d rotation;

--- a/teaser/src/graph.cc
+++ b/teaser/src/graph.cc
@@ -60,6 +60,11 @@ vector<int> teaser::MaxCliqueSolver::findMaxClique(teaser::Graph graph) {
   }
 
   assert(in.lb != 0);
+  if (in.lb == 0) {
+    // This means that max clique has a size of one
+    TEASER_DEBUG_ERROR_MSG("Max clique lb equals to zero. Abort.");
+    return C;
+  }
 
   if (in.lb == in.ub) {
     return C;

--- a/teaser/src/graph.cc
+++ b/teaser/src/graph.cc
@@ -62,7 +62,7 @@ vector<int> teaser::MaxCliqueSolver::findMaxClique(teaser::Graph graph) {
   assert(in.lb != 0);
   if (in.lb == 0) {
     // This means that max clique has a size of one
-    TEASER_DEBUG_ERROR_MSG("Max clique lb equals to zero. Abort.");
+    TEASER_DEBUG_ERROR_MSG("Max clique lower bound equals to zero. Abort.");
     return C;
   }
 

--- a/teaser/src/registration.cc
+++ b/teaser/src/registration.cc
@@ -462,6 +462,12 @@ teaser::RobustRegistrationSolver::solve(const Eigen::Matrix<double, 3, Eigen::Dy
   std::copy(max_clique_.begin(), max_clique_.end(), std::ostream_iterator<int>(std::cout, " "));
   std::cout << std::endl;
 #endif
+  // Abort if max clique size <= 1
+  if (max_clique_.size() <= 1) {
+    TEASER_DEBUG_INFO_MSG("Clique size too small. Abort.");
+    solution_.valid = false;
+    return solution_;
+  }
 
   // Calculate new measurements & TIMs based on max clique inliers
   Eigen::Matrix<double, 3, Eigen::Dynamic> pruned_src(3, max_clique_.size());
@@ -518,6 +524,9 @@ teaser::RobustRegistrationSolver::solve(const Eigen::Matrix<double, 3, Eigen::Dy
 
   // Find the final inliers
   translation_inliers_ = utils::maskVector<int>(translation_inliers_mask_, rotation_inliers_);
+
+  // Update validity flag
+  solution_.valid = true;
 
   return solution_;
 }


### PR DESCRIPTION
Added check for maximum clique size in the `solve` function.

Also include a boolean flag in the solution struct to notify users whether the solution is valid (i.e., not aborted).