### PR TITLE
Change mex symbol visibility in matlab/CMakeLists

### DIFF
--- a/matlab/CMakeLists.txt
+++ b/matlab/CMakeLists.txt
@@ -12,7 +12,7 @@ if (Matlab_FOUND)
             SRC teaser_mex.cc
             LINK_TO Eigen3::Eigen teaser_registration
     )
-
+    set_target_properties(teaser_mex PROPERTIES COMPILE_FLAGS "-fvisibility=default")
     # copy MATLAB .m files to binary directory
     file(COPY .
             DESTINATION .


### PR DESCRIPTION
This PR addresses a `Invalid MEX-file: Gateway function is missing` error encountered in MATLAB r2018b.  Apparently the mexFunction symbol is not generated with the correct visibility settings by default, as of r2018b.  See this GitHub discussion: 

https://github.com/DIPlib/diplib/issues/13

and this related discussion on GitLab:

https://gitlab.dune-project.org/duneuro/duneuro-matlab/commit/8d3d06c691f48d5528e562473d4967d7de77e834

Other information: Ubuntu 18.04, compiling mex with g++ 7.4.0.  