### PR TITLE
minor matlab fixes

### DIFF
--- a/matlab/CMakeLists.txt
+++ b/matlab/CMakeLists.txt
@@ -14,10 +14,9 @@ if (Matlab_FOUND)
     )
     set_target_properties(teaser_mex PROPERTIES COMPILE_FLAGS "-fvisibility=default")
     # copy MATLAB .m files to binary directory
-    file(COPY .
-            DESTINATION .
-            FILES_MATCHING
-            PATTERN *.m)
+    add_custom_command(TARGET teaser_mex POST_BUILD
+            COMMAND ${CMAKE_COMMAND} -E copy
+                ${CMAKE_CURRENT_SOURCE_DIR}/*.m $<TARGET_FILE_DIR:teaser_mex>)
 else ()
     message(WARNING "MATLAB root directory not found. Failed to build MATLAB bindings.")
     set(BUILD_MATLAB_BINDINGS OFF)

--- a/matlab/teaser_solve_test.m
+++ b/matlab/teaser_solve_test.m
@@ -8,11 +8,13 @@ rot_alg = 0;
 rot_gnc_factor = 1.4;
 rot_max_iters = 100;
 rot_cost_threshold = 1e-12;
+inlier_arg = 0;
+kcore_thr = 0.5;
 
 % Test the MEX function
 [s, R, t, time_taken] = teaser_solve_mex(src, dst, cbar2, ...
         noise_bound, estimate_scaling, rot_alg, rot_gnc_factor, ...
-        rot_max_iters, rot_cost_threshold);
+        rot_max_iters, rot_cost_threshold, inlier_arg, kcore_thr);
 assert(s==1);
 assert(norm(R-eye(3)) < 1e-5);
 assert(norm(t-[1;0;1]) < 1e-5);


### PR DESCRIPTION
Very minor matlab fixes:
- added missing mex args for `teaser_solve_test.m`
- modernized CMakeLists to make copying the matlab files part of the `teaser_mex` target (any time `teaser_mex` target needs to be rebuilt, will re-copy matlab files over)