### PR TITLE
Correctly clear graph and inlier vectors after calls to solve()

### DIFF
--- a/teaser/include/teaser/graph.h
+++ b/teaser/include/teaser/graph.h
@@ -180,6 +180,14 @@ public:
   void reserve(const int& num_vertices) { adj_list_.reserve(num_vertices); }
 
   /**
+   * Clear the contents of the graph
+   */
+  void clear() {
+    adj_list_.clear();
+    num_edges_ = 0;
+  }
+
+  /**
    * Reserve space for complete graph. A complete undirected graph should have N*(N-1)/2 edges
    * @param num_vertices
    */
@@ -210,7 +218,6 @@ private:
  */
 class MaxCliqueSolver {
 public:
-
   /**
    * Enum representing the solver algorithm to use
    */

--- a/teaser/include/teaser/registration.h
+++ b/teaser/include/teaser/registration.h
@@ -770,6 +770,7 @@ public:
     max_clique_.clear();
     rotation_inliers_.clear();
     translation_inliers_.clear();
+    inlier_graph_.clear();
   }
 
   /**

--- a/teaser/include/teaser/registration.h
+++ b/teaser/include/teaser/registration.h
@@ -765,11 +765,16 @@ public:
     // Initialize the translation estimator
     setTranslationEstimator(
         std::make_unique<teaser::TLSTranslationSolver>(params_.noise_bound, params_.cbar2));
+
+    // Clear member variables
+    max_clique_.clear();
+    rotation_inliers_.clear();
+    translation_inliers_.clear();
   }
 
   /**
    * Return the params
-   * @return a Params truct
+   * @return a Params struct
    */
   Params getParams() { return params_; }
 


### PR DESCRIPTION
This bug causes TEASER++ solver to report incorrect matches after calling solve() for more than once. The issue is that after calling solve(), the member variables are not clear. Users try to call reset(), but reset() is also not clearing the variables. This PR fixes it.