### PR TITLE
Wrong rotation function parameters correction.

### DIFF
--- a/examples/teaser_python_3dsmooth/line_mesh.py
+++ b/examples/teaser_python_3dsmooth/line_mesh.py
@@ -73,7 +73,7 @@ class LineMesh(object):
                 axis_a = axis * angle
                 R = o3d.geometry.get_rotation_matrix_from_axis_angle(axis_a)
                 cylinder_segment = cylinder_segment.rotate(
-                    R, center=True)
+                    R, center=np.zeros([3, 1], dtype=np.float64))
             # color cylinder
             color = self.colors if self.colors.ndim == 1 else self.colors[i, :]
             cylinder_segment.paint_uniform_color(color)


### PR DESCRIPTION
Thanks for the release.
I followed the instructions to compile the code, and try to reproduce the [GIF showed in profile](https://github.com/MIT-SPARK/TEASER-plusplus#reproduce-the-gif-above). When I ran

```python teaser_python_3dsmooth.py```

there was a bug:

```
TypeError: rotate(): incompatible function arguments. The following argument types are supported:
    1. (self: open3d.open3d_pybind.geometry.Geometry3D, R: numpy.ndarray[float64[3, 3]], center: numpy.ndarray[float64[3, 1]]) -> open3d.open3d_pybind.geometry.Geometry3D

Invoked with: geometry::TriangleMesh with 102 points and 200 triangles., array([[ 0.99154181, -0.09292577, -0.09060704],
       [-0.09292577, -0.02092779, -0.99545308],
       [ 0.09060704,  0.99545308, -0.02938598]]); kwargs: center=True
```

It might be wrong parameter. Perhaps it should be coordinate origin (0, 0, 0). I'm not very sure if correcting it this way would cause a new problem, but it works for me, maybe try it.

