### PR TITLE
Faster 1D TLS estimation

### DIFF
--- a/teaser/src/registration.cc
+++ b/teaser/src/registration.cc
@@ -32,10 +32,9 @@ void teaser::ScalarTLSEstimator::estimate(const Eigen::RowVectorXd& X,
 
   int N = X.cols();
   std::vector<std::pair<double, int>> h;
-  for (size_t i= 0 ;i < N ;++i)
-  {
-      h.push_back(std::make_pair(X(i) - ranges(i), i+1));
-      h.push_back(std::make_pair(X(i) + ranges(i), -i-1));
+  for (size_t i= 0 ;i < N ;++i){
+    h.push_back(std::make_pair(X(i) - ranges(i), i+1));
+    h.push_back(std::make_pair(X(i) + ranges(i), -i-1));
   }
 
   // ascending order
@@ -57,20 +56,20 @@ void teaser::ScalarTLSEstimator::estimate(const Eigen::RowVectorXd& X,
 
   for (size_t i = 0 ; i < nr_centers ; ++i){
 
-      int idx = int(std::abs(h.at(i).second)) - 1; // Indices starting at 1
-      int epsilon = (h.at(i).second > 0) ? 1 : -1;
+    int idx = int(std::abs(h.at(i).second)) - 1; // Indices starting at 1
+    int epsilon = (h.at(i).second > 0) ? 1 : -1;
 
-      consensus_set_cardinal += epsilon;
-      dot_weights_consensus += epsilon * weights(idx);
-      dot_X_weights += epsilon * weights(idx) * X(idx);
-      ranges_inverse_sum -= epsilon * ranges(idx);
-      sum_xi += epsilon * X(idx);
-      sum_xi_square += epsilon * X(idx) * X(idx);
+    consensus_set_cardinal += epsilon;
+    dot_weights_consensus += epsilon * weights(idx);
+    dot_X_weights += epsilon * weights(idx) * X(idx);
+    ranges_inverse_sum -= epsilon * ranges(idx);
+    sum_xi += epsilon * X(idx);
+    sum_xi_square += epsilon * X(idx) * X(idx);
 
-      x_hat(i) = dot_X_weights / dot_weights_consensus;
+    x_hat(i) = dot_X_weights / dot_weights_consensus;
 
-      double residual = consensus_set_cardinal * x_hat(i) * x_hat(i) + sum_xi_square  - 2 * sum_xi * x_hat(i);
-      x_cost(i) = residual + ranges_inverse_sum;
+    double residual = consensus_set_cardinal * x_hat(i) * x_hat(i) + sum_xi_square  - 2 * sum_xi * x_hat(i);
+    x_cost(i) = residual + ranges_inverse_sum;
       
   }
 

--- a/teaser/src/registration.cc
+++ b/teaser/src/registration.cc
@@ -30,7 +30,6 @@ void teaser::ScalarTLSEstimator::estimate(const Eigen::RowVectorXd& X,
   assert(!dimension_inconsistent);
   assert(!only_one_element); // TODO: admit a trivial solution
 
-
   int N = X.cols();
   std::vector<std::pair<double, int>> h;
   for (size_t i= 0 ;i < N ;++i)
@@ -58,7 +57,7 @@ void teaser::ScalarTLSEstimator::estimate(const Eigen::RowVectorXd& X,
 
   for (size_t i = 0 ; i < nr_centers ; ++i){
 
-      int idx = int(std::abs(h.at(i).second))-1; // Indices starting at 1
+      int idx = int(std::abs(h.at(i).second)) - 1; // Indices starting at 1
       int epsilon = (h.at(i).second > 0) ? 1 : -1;
 
       consensus_set_cardinal += epsilon;

--- a/teaser/src/registration.cc
+++ b/teaser/src/registration.cc
@@ -30,51 +30,49 @@ void teaser::ScalarTLSEstimator::estimate(const Eigen::RowVectorXd& X,
   assert(!dimension_inconsistent);
   assert(!only_one_element); // TODO: admit a trivial solution
 
-  // Prepare variables for calculations
+
   int N = X.cols();
-  Eigen::RowVectorXd h(N * 2);
-  h << X - ranges, X + ranges;
+  std::vector<std::pair<double, int>> h;
+  for (size_t i= 0 ;i < N ;++i)
+  {
+      h.push_back(std::make_pair(X(i) - ranges(i), i+1));
+      h.push_back(std::make_pair(X(i) + ranges(i), -i-1));
+  }
+
   // ascending order
-  std::sort(h.data(), h.data() + h.cols(), [](double a, double b) { return a < b; });
-  // calculate interval centers
-  Eigen::RowVectorXd h_centers = (h.head(h.cols() - 1) + h.tail(h.cols() - 1)) / 2;
-  auto nr_centers = h_centers.cols();
+  std::sort(h.begin(), h.end(), [](std::pair<double, int> a, std::pair<double, int> b) { return a.first < b.first; });
 
   // calculate weights
   Eigen::RowVectorXd weights = ranges.array().square();
   weights = weights.array().inverse();
-
+  int nr_centers = 2 * N;
   Eigen::RowVectorXd x_hat = Eigen::MatrixXd::Zero(1, nr_centers);
   Eigen::RowVectorXd x_cost = Eigen::MatrixXd::Zero(1, nr_centers);
 
-#pragma omp parallel for default(none)                                                             \
-    shared(N, nr_centers, h_centers, X, ranges, weights, x_hat, x_cost)
-  for (size_t i = 0; i < nr_centers; ++i) {
-    double ranges_inverse_sum = 0;
-    double dot_X_weights = 0;
-    double dot_weights_consensus = 0;
-    std::vector<double> X_consensus_vec;
+  double ranges_inverse_sum = ranges.sum();
+  double dot_X_weights = 0;
+  double dot_weights_consensus = 0;
+  int consensus_set_cardinal = 0;
+  double sum_xi = 0; 
+  double sum_xi_square = 0;
 
-    for (size_t j = 0; j < N; ++j) {
-      // consensus = (abs(X-h_centers(i)) <= ranges);
-      bool consensus = std::abs(X(j) - h_centers(i)) <= ranges(j);
-      if (consensus) {
-        dot_X_weights += X(j) * weights(j);
-        dot_weights_consensus += weights(j);
-        X_consensus_vec.push_back(X(j));
-      } else {
-        ranges_inverse_sum += ranges(j);
-      }
-    }
-    // x_hat(i) = dot(X(consensus), weights(consensus)) / dot(weights, consensus);
-    x_hat(i) = dot_X_weights / dot_weights_consensus;
+  for (size_t i = 0 ; i < nr_centers ; ++i){
 
-    // residual = X(consensus)-x_hat(i);
-    Eigen::Map<Eigen::VectorXd> X_consensus(X_consensus_vec.data(), X_consensus_vec.size());
-    Eigen::VectorXd residual = X_consensus.array() - x_hat(i);
+      int idx = int(std::abs(h.at(i).second))-1; // Indices starting at 1
+      int epsilon = (h.at(i).second > 0) ? 1 : -1;
 
-    // x_cost(i) = dot(residual,residual) + sum(ranges(~consensus));
-    x_cost(i) = residual.squaredNorm() + ranges_inverse_sum;
+      consensus_set_cardinal += epsilon;
+      dot_weights_consensus += epsilon * weights(idx);
+      dot_X_weights += epsilon * weights(idx) * X(idx);
+      ranges_inverse_sum -= epsilon * ranges(idx);
+      sum_xi += epsilon * X(idx);
+      sum_xi_square += epsilon * X(idx) * X(idx);
+
+      x_hat(i) = dot_X_weights / dot_weights_consensus;
+
+      double residual = consensus_set_cardinal * x_hat(i) * x_hat(i) + sum_xi_square  - 2 * sum_xi * x_hat(i);
+      x_cost(i) = residual + ranges_inverse_sum;
+      
   }
 
   size_t min_idx;


### PR DESCRIPTION
Hi Heng and Jingnan,

Thanks for the code!
Following up on our discussion, here are the updates to speedup 1D TLS estimation. The main insight is that by keeping a few variables in memory, we can do a single pass over all intervals and directly estimate the local minima in each of the consensus sets while looping which saves us an inner loop. The resulting time complexity is O(NlogN) instead of O(N^2)

I tried parallelizing the code but it turns out that since the bottleneck is the sort in O(Nlog(N)) it doesn't make much of a difference. I actually had worse results parallelizing the code on a few examples.