### PR TITLE
drop gtest targets from install command

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,7 +81,7 @@ execute_process(COMMAND "${CMAKE_COMMAND}" --build .
         WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/googletest-download")
 set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
 add_subdirectory("${CMAKE_BINARY_DIR}/googletest-src"
-        "${CMAKE_BINARY_DIR}/googletest-build")
+        "${CMAKE_BINARY_DIR}/googletest-build" EXCLUDE_FROM_ALL)
 
 # pmc (Parallel Maximum Clique)
 configure_file(cmake/pmc.CMakeLists.txt.in pmc-download/CMakeLists.txt)


### PR DESCRIPTION
@jingnanshi I noticed that gtest was getting installed along with teaserpp even though it's being statically linked / isn't necessary to build against teaserpp. This should fix it